### PR TITLE
UseFlags option treats messages \\Flagged but not \\Seen as spam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+antispam
+config.json
+filter.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,8 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates
 
 RUN update-ca-certificates
+WORKDIR /app/
+ADD config.json /app/
+RUN touch /tmp/antispam-filter.json
 COPY --from=builder /go/bin/antispam /bin/antispam
 ENTRYPOINT ["/bin/antispam"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,9 @@ RUN ls -l \
 
 # Then, package
 FROM debian:buster-slim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates
+
+RUN update-ca-certificates
 COPY --from=builder /go/bin/antispam /bin/antispam
 ENTRYPOINT ["/bin/antispam"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 REV:=$(shell git rev-parse HEAD)
 CONTAINER_TAG=parkr/antispam:$(REV)
+LATEST_TAG=parkr/antispam:latest
 
 all: build test
 
@@ -42,3 +43,5 @@ docker-test: docker-build
 
 docker-release: docker-build
 	docker push $(CONTAINER_TAG)
+	docker tag $(CONTAINER_TAG) $(LATEST_TAG)
+	docker push $(LATEST_TAG)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 REV:=$(shell git rev-parse HEAD)
+CONTAINER_TAG=parkr/antispam:$(REV)
 
 all: build test
 
@@ -31,13 +32,13 @@ clean:
 	rm -f antispam
 
 dive: docker-build
-	dive parkr/antispam:$(REV)
+	dive $(CONTAINER_TAG)
 
 docker-build: Dockerfile *.go
-	docker build -t parkr/antispam:$(REV) .
+	docker build -t $(CONTAINER_TAG) .
 
 docker-test: docker-build
-	docker run parkr/antispam:$(REV) -h
+	docker run $(CONTAINER_TAG) -h
 
 docker-release: docker-build
-	docker push parkr/antispam:$(REV)
+	docker push $(CONTAINER_TAG)

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ statik:
 bundle: statik
 	statik -f -src=$(shell pwd)/blocklists
 
-build: bundle
+build: bundle *.go
 	go install ./...
+	go build ./...
 
 test: bundle vet lint
 	go test ./...
@@ -30,7 +31,7 @@ clean:
 dive: docker-build
 	dive parkr/antispam:$(REV)
 
-docker-build:
+docker-build: Dockerfile *.go
 	docker build -t parkr/antispam:$(REV) .
 
 docker-test: docker-build

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ vet:
 lint: golint
 	golint ./...
 
+clean:
+	rm -f statik/statik.go
+
 dive: docker-build
 	dive parkr/antispam:$(REV)
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ bundle: statik
 build: bundle *.go
 	go install ./...
 	go build ./...
+	go build .
 
 test: bundle vet lint
 	go test ./...
@@ -27,6 +28,7 @@ lint: golint
 
 clean:
 	rm -f statik/statik.go
+	rm -f antispam
 
 dive: docker-build
 	dive parkr/antispam:$(REV)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ statik:
 	go get github.com/rakyll/statik
 
 bundle: statik
-	statik -src=$(shell pwd)/blocklists
+	statik -f -src=$(shell pwd)/blocklists
 
 build: bundle
 	go install ./...

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ go get -u github.com/parkr/antispam
 
 ## Configuring
 
-Configuration is via a JSON file. It has 6 possible fields, but only 4 are required:
+Configuration is via a JSON file. It has 10 possible fields, but only the first 4 are required:
 
 ```json
 {
@@ -27,13 +27,23 @@ Configuration is via a JSON file. It has 6 possible fields, but only 4 are requi
   "Username": "email@example.com",
   "Password": "myplaintextpassword"
   "UseJunk": true,
-  "UseSpam": true
+  "UseSpam": true,
+  "UseFlags": false,
+  "UseBlockLists": true,
 }
 ```
 
 That will log into `mail.example.com:993` as `email@example.com` with password `myplaintextpassword`. Easy!
 
-Two optional configuration options are `BadEmailDomains` and `BadEmails`.
+UseJunk and UseSpam will cause antispam to scan folders Junk and Spam,
+respectively.
+
+UseFlags will cause any message flagged but unread to be treated as spam. The
+flag will be cleared before the message is deleted.
+
+UseBlockLists uses the union of the included statik blocklist files plus
+BadEmailDomains and BadEmail, if present.
+
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Configuration is via a JSON file. It has 6 possible fields, but only 4 are requi
   "Port": "993",
   "Username": "email@example.com",
   "Password": "myplaintextpassword"
+  "UseJunk": true,
+  "UseSpam": true
 }
 ```
 
@@ -48,5 +50,5 @@ Two optional configuration options are `BadEmailDomains` and `BadEmails`.
 ## Usage
 
 ```console
-$ antispam -config=path/to/config.json -num=50
+$ make && ./antispam -config path/to/config.json -filter path/to/filter.json --num=50
 ```

--- a/antispam.go
+++ b/antispam.go
@@ -94,16 +94,18 @@ func main() {
 		filterFile = &defaultFilterFile
 	}
 
-	conf := &config{}
+	conf := &config{UseSpam: true, UseJunk: true}
 	log.Println("Reading config...")
 	if err := readConfigFile(conf, *confFile); err != nil {
 		panic(err)
 	}
+	log.Println("Read config", conf)
 
 	log.Printf("Reading filter file %s", *filterFile)
 	if err := readConfigFile(conf, *filterFile); err != nil {
 		panic(err)
 	}
+	log.Println("Read filter", conf)
 
 	log.Println("Loading global blocklists...")
 	readGlobalBlocklists()
@@ -146,9 +148,14 @@ func main() {
 	close(done)
 
 	numMessages := uint32(*numMessagesFromFlag)
-	processJunkFolder(c, conf, "Junk", numMessages) // Things we manually label as Junk will be added to our config.
-	processJunkFolder(c, conf, "Spam", numMessages) // Things we manually label as Junk will be added to our config.
-	processInbox(c, conf, numMessages)              // Remove spam from the inbox.
+
+	if conf.UseJunk {
+		processJunkFolder(c, conf, "Junk", numMessages) // Things we manually label as Junk will be added to our config.
+	}
+	if conf.UseSpam {
+		processJunkFolder(c, conf, "Spam", numMessages) // Things we manually label as Junk will be added to our config.
+	}
+	processInbox(c, conf, numMessages) // Remove spam from the inbox.
 
 	writeNewFilterFile(*filterFile, conf)
 

--- a/antispam.go
+++ b/antispam.go
@@ -89,7 +89,14 @@ func main() {
 	flag.Parse()
 
 	if *confFile == "" {
-		panic("Specify the -config flag")
+		// If DefaultConfig works, use it, else panic
+		f, err := os.Open(DefaultConfig)
+		if err != nil {
+			panic("Specify the -config flag")
+		}
+		f.Close()
+
+		*confFile = DefaultConfig
 	}
 
 	if *debugFlag {

--- a/config.go
+++ b/config.go
@@ -16,6 +16,8 @@ type config struct {
 	BadEmailDomains, BadEmails []string `json:",omitempty"`
 	UseJunk                    bool     `json:",omitempty"`
 	UseSpam                    bool     `json:",omitempty"`
+	UseFlags                   bool     `json:",omitempty"`
+	UseBlockLists              bool     `json:",omitempty"`
 }
 
 func readConfigFile(conf *config, filename string) error {

--- a/config.go
+++ b/config.go
@@ -14,6 +14,8 @@ type config struct {
 	Address, Port              string   `json:",omitempty"`
 	Username, Password         string   `json:",omitempty"`
 	BadEmailDomains, BadEmails []string `json:",omitempty"`
+	UseJunk                    bool     `json:",omitempty"`
+	UseSpam                    bool     `json:",omitempty"`
 }
 
 func readConfigFile(conf *config, filename string) error {

--- a/config.go
+++ b/config.go
@@ -10,6 +10,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const DefaultConfig = "config.json"
+
 type config struct {
 	Address, Port              string   `json:",omitempty"`
 	Username, Password         string   `json:",omitempty"`

--- a/example.json
+++ b/example.json
@@ -1,0 +1,8 @@
+{
+  "Address": "imap.example.com",
+  "Port": "993",
+  "Username": "user@example.com",
+  "Password": "example-password",
+  "BadEmailDomains": ["horriblehepsebah.com", "iwillspamyou.biz"],
+  "BadEmails": ["somenastyspammer@gmail.com", "someonewhoseaccountwascompromised@verizon.net"]
+}

--- a/example.json
+++ b/example.json
@@ -4,5 +4,7 @@
   "Username": "user@example.com",
   "Password": "example-password",
   "BadEmailDomains": ["horriblehepsebah.com", "iwillspamyou.biz"],
-  "BadEmails": ["somenastyspammer@gmail.com", "someonewhoseaccountwascompromised@verizon.net"]
+  "BadEmails": ["somenastyspammer@gmail.com", "someonewhoseaccountwascompromised@verizon.net"],
+  "UseJunk": true,
+  "UseSpam": true
 }

--- a/example.json
+++ b/example.json
@@ -6,5 +6,7 @@
   "BadEmailDomains": ["horriblehepsebah.com", "iwillspamyou.biz"],
   "BadEmails": ["somenastyspammer@gmail.com", "someonewhoseaccountwascompromised@verizon.net"],
   "UseJunk": true,
-  "UseSpam": true
+  "UseSpam": true,
+  "UseFlags": false,
+  "UseBlockLists": true
 }

--- a/statik/.gitignore
+++ b/statik/.gitignore
@@ -1,0 +1,1 @@
+statik.go


### PR DESCRIPTION
- fetches flags in addition to envelope
- if `UseFlags`, look for `\\Flagged` but not `\\Seen` and mark as spammy
- `\\Flagged` is always cleared before spam is deleted
- `UseBlockLists` flags (default: `true`) enables global BlockList parsing
- Make container building/deployment slightly easier, config.json by default

(Will rebase once #39 is merged.)